### PR TITLE
added rounding before converting float32 to uint8

### DIFF
--- a/adversarial_vision_challenge/common.py
+++ b/adversarial_vision_challenge/common.py
@@ -20,6 +20,7 @@ def check_image(image):
         if image.max() > 255:
             logger.warning('clipped value greater than 255 to 255')
         image = np.clip(image, 0, 255)
+        image = image.round()
         image = image.astype(np.uint8)
     assert image.dtype == np.uint8
     return image


### PR DESCRIPTION
Following the discussion on Gitter (see following quote from me) and some offline discussions we have decided to add proper rounding before converting floats to integers. While attacks could do this themselves, we haven't see many attacks actually doing it (acutally our own baselines also don't do it) and the current way of rounding is just not what one would expect.

> **@jonasrauber:**
Hi @csy530216, thank you for your in-depth analysis of this issue. I'll try to help! So far I am not fully convinced yet that we actually have a problem that needs fixing, but let's discuss further. While it would be nice to support small per pixel perturbations (< 1 for pixel values between 0 and 255) we cannot do that because that would give models an easy way to detect most adversarial perturbations (clean images only have integer values). So to avoid leaking information to the model, we are enforcing that all adversarials are in uint8 format as well. In other words: the smallest possible (non-zero) perturbation for each pixel is 1. Note that we do not just convert to uint8 in store_adversarial (i.e. when saving the adversarial and calculating the distance), but also during inference (the model always only gets integer inputs). In that sense we determine the size of the actual perturbation seen by the model and whether we map [i, i+1) to i or [i - 0.5, i + 0.5) should in principle not matter: Actually your attack could just add 0.5 to everything it passes to the model and you would get the desired behavior. Nevertheless, I see that, from a practical point of view, it's nicer if we do that (i.e. rounding to the nearest integer == adding 0.5 before rounding down). Not sure if it's worth changing the interface for that, however (in theory someone might have already built upon the current assumptions). What do you think?

This pull-request contains the necessary changes (actually it's just adding one line). This will affect both `predict` and `store_adversarial`.

@spMohanty Can you confirm that, once we release this as a new version, this will automatically be part of all new submissions and the evaluation coming up these days (if released before then)
@wielandbrendel Can you decide when to do go live with this update (I think I would risk doing it now, before the evaluation.)
@bveliqi Can you review and merge this PR and release a new version as soon as @wielandbrendel gives his okay.